### PR TITLE
Include semester fallback for modules if not found in active semester

### DIFF
--- a/site/src/routes/modules/[year]/[semesterNum]/[moduleCode]/+page.server.ts
+++ b/site/src/routes/modules/[year]/[semesterNum]/[moduleCode]/+page.server.ts
@@ -5,22 +5,38 @@ import { collection, getDocs, query, where } from 'firebase/firestore';
 
 export async function load({ params }) {
     const { moduleCode, year, semesterNum } = params;
+    const semesterTitle = getSemesterTitle(year, semesterNum);
+
+    let documents = await getModuleDocs(moduleCode, semesterNum, year);
+
+    if (documents.length == 0) {
+        documents = await getModuleDocs(moduleCode);
+
+        if (documents.length == 0) error(404, { message: `Module ${moduleCode} not found!` });
+        else {
+            const module = documents.map((doc) => doc.data())[0] as Module;
+            return { year, semesterNum, module, semesterTitle, currentSemester: false };
+        }
+    } else {
+        const module = documents.map((doc) => doc.data())[0] as Module;
+        return { year, semesterNum, module, semesterTitle, currentSemester: true };
+    }
+}
+
+async function getModuleDocs(code: string, semesterNum: string = '', year: string = '') {
+    const wheres = [where('code', '==', code)];
+    if (semesterNum != '') wheres.push(where('semester_num', '==', semesterNum));
+    if (year != '') wheres.push(where('year', '==', year));
 
     const modulesCollection = collection(db, COLL_MODULES);
-    const modulesQuery = query(
-        modulesCollection,
-        where('code', '==', moduleCode),
-        where('semester_num', '==', semesterNum),
-        where('year', '==', year)
-    );
+    const modulesQuery = query(modulesCollection, ...wheres);
 
     const querySnapshot = await getDocs(modulesQuery);
     const documents = querySnapshot.docs;
+    return documents;
+}
 
-    if (documents.length == 0) {
-        error(404, { message: `Module ${moduleCode} not found!` });
-    } else {
-        const module = querySnapshot.docs.map((doc) => doc.data())[0] as Module;
-        return { year, semesterNum, module };
-    }
+function getSemesterTitle(year: string, semesterNum: string) {
+    const ay = `${year}/${parseInt(year.slice(-2)) + 1}`;
+    return `AY ${ay} Semester ${semesterNum}`;
 }

--- a/site/src/routes/modules/[year]/[semesterNum]/[moduleCode]/+page.svelte
+++ b/site/src/routes/modules/[year]/[semesterNum]/[moduleCode]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import Info from '$lib/assets/images/Info.svelte';
     import sanitizeHtml from 'sanitize-html';
     import { goto } from '$app/navigation';
     import Timetable from '$lib/components/timetable/Timetable.svelte';
@@ -79,23 +80,33 @@
         <div class="pl-8 ml-4">
             <h2 class="text-xl font-medium">{$t('Modules.Details.Schedule')}</h2>
             <div class="divider mt-0 mb-4" />
-            <div class="flex justify-center items-center pb-4">
-                <span>{$t('Modules.Details.Index Number')}</span>
-                <select
-                    class="select border border-solid border-neutral ml-4"
-                    bind:value={indexNumber}
-                    on:change={updateIndex}
+            {#if !data.currentSemester}
+                <div
+                    role="alert"
+                    class="alert alert-warning flex justify-center font-semibold mb-4"
                 >
-                    <!-- <option value="-1">-Select one-</option> -->
-                    {#each indexNumbers as indexNumber}
-                        <option value={indexNumber}>{indexNumber}</option>
-                    {/each}
-                </select>
-            </div>
-            <Timetable
-                {lessons}
-                orientation="portrait"
-            />
+                    <Info />
+                    <span>{data.module.code} is not offered in {data.semesterTitle}</span>
+                </div>
+            {:else}
+                <div class="flex justify-center items-center pb-4">
+                    <span>{$t('Modules.Details.Index Number')}</span>
+                    <select
+                        class="select border border-solid border-neutral ml-4"
+                        bind:value={indexNumber}
+                        on:change={updateIndex}
+                    >
+                        <!-- <option value="-1">-Select one-</option> -->
+                        {#each indexNumbers as indexNumber}
+                            <option value={indexNumber}>{indexNumber}</option>
+                        {/each}
+                    </select>
+                </div>
+                <Timetable
+                    {lessons}
+                    orientation="portrait"
+                />
+            {/if}
         </div>
     </div>
 </div>


### PR DESCRIPTION
If routed to module detail page and it isn't found for the semester provided, use a fallback where it checks only for the module code and display a warning that the module isn't offered in the semester.