### PR TITLE
Fix vertical timetable lesson cell overlap

### DIFF
--- a/site/src/lib/components/timetable/TimetableCell.svelte
+++ b/site/src/lib/components/timetable/TimetableCell.svelte
@@ -19,7 +19,7 @@
     // Very important to ensure each column's initial width can fit the full cell.
     const portraitStyle =
         top !== undefined && height !== undefined
-            ? `position: absolute; top: calc(${top}% + 4px); height: calc(${height}% - 4px); width: 95%`
+            ? `position: relative; top: calc(${top}% + 4px); height: calc(${height}% - 4px); width: 95%`
             : '';
 
     const clashClass = clashing ? 'border-3 border-solid border-error' : 'border border-neutral';

--- a/site/src/lib/components/timetable/TimetableColumn.svelte
+++ b/site/src/lib/components/timetable/TimetableColumn.svelte
@@ -35,7 +35,7 @@
     >
         {day}
     </div>
-    <div class="relative flex h-full pl-1 rounded-lg bg-tt-alternate-v bg-tt-loop">
+    <div class="relative flex h-full min-w-full pl-1 rounded-lg bg-tt-alternate-v bg-tt-loop w-max">
         {#each groups as group}
             <div class="flex flex-col">
                 {#each group as cellDetails}
@@ -49,6 +49,5 @@
                 {/each}
             </div>
         {/each}
-        <div></div>
     </div>
 </li>

--- a/site/src/lib/components/timetable/day-helper.ts
+++ b/site/src/lib/components/timetable/day-helper.ts
@@ -161,7 +161,6 @@ export function intervalsToGroups<T extends RowCellDetails | ColCellDetails>(int
             // else, check for earliest group that supports the cell
             // by checking the end time of the last cell in a group.
             // it's fine as intervals is already sorted.
-
             let stored = false;
             for (let j = 0; j < groups.length; j++) {
                 const group = groups[j];
@@ -212,8 +211,14 @@ export function calculateCellLeftOffsets(groups: RowCellDetails[][]) {
 export function calculateCellTopOffsets(groups: ColCellDetails[][]) {
     groups = groups.map((group) => {
         return group.reduce(
-            (acc, cell) => {
-                cell.accTop = cell.top + cell.height;
+            (acc, cell, i) => {
+                if (i === 0) {
+                    cell.accTop = cell.top + cell.height;
+                } else {
+                    const newtop = cell.top - (acc[i - 1].accTop ?? 0);
+                    cell.top = newtop;
+                    cell.accTop = (acc[i - 1].accTop ?? 0) + cell.top + cell.height;
+                }
                 return [...acc, cell];
             },
             <ColCellDetails[]>[]


### PR DESCRIPTION
Closes #57

It didn't space out columns previously. 

![image](https://github.com/Benjababe/ntumoons/assets/19561469/7cf1bd6e-e017-4bd6-8741-02ac3e9d8e2e)
